### PR TITLE
Switch from pkg_resources to importlib.metadata

### DIFF
--- a/colcon_installed_package_information/package_augmentation/python.py
+++ b/colcon_installed_package_information/package_augmentation/python.py
@@ -6,7 +6,7 @@ import sysconfig
 try:
     from importlib.metadata import Distribution
 except ImportError:
-    # TODO: Drop this with Python 3.7 support
+    # TODO: Drop this when dropping Python 3.7 support
     from importlib_metadata import Distribution
 
 from colcon_core.package_augmentation \

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords = colcon
 python_requires = >=3.6
 install_requires =
   colcon-core
+  importlib-metadata; python_version < "3.8"
 packages = find:
 zip_safe = true
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-installed-package-information]
 No-Python2:
-Depends3: python3-colcon-core
+Depends3: python3-colcon-core, python3 (>= 3.8) | python3-importlib-metadata
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,8 @@ apache
 colcon
 deps
 descs
+dists
+importlib
 iterdir
 linter
 noqa
@@ -18,3 +20,4 @@ scspell
 setuptools
 sysconfig
 thomas
+todo


### PR DESCRIPTION
This is a fairly clean swap, but one unintended side effect I noticed is that the "extras" dependencies are now enumerated as runtime dependencies. This is probably the right behavior for a typical "extra", but isn't really right for the "test" extras we use to declare test dependencies because these packages have already been installed and therefore will never need their test dependencies again.

Some refactoring in colcon-core may be able to alleviate this.